### PR TITLE
[Backport] Special price date from issue resolve

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper.php
@@ -463,7 +463,6 @@ class Helper
     private function convertSpecialFromDateStringToObject($productData)
     {
         if (isset($productData['special_from_date']) && $productData['special_from_date'] != '') {
-            $productData['special_from_date'] =  $this->dateFilter->filter($productData['special_from_date']);
             $productData['special_from_date'] = new \DateTime($productData['special_from_date']);
         }
 

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper.php
@@ -463,6 +463,7 @@ class Helper
     private function convertSpecialFromDateStringToObject($productData)
     {
         if (isset($productData['special_from_date']) && $productData['special_from_date'] != '') {
+            $productData['special_from_date'] = $this->dateFilter->filter($productData['special_from_date']);
             $productData['special_from_date'] = new \DateTime($productData['special_from_date']);
         }
 

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper.php
@@ -463,6 +463,7 @@ class Helper
     private function convertSpecialFromDateStringToObject($productData)
     {
         if (isset($productData['special_from_date']) && $productData['special_from_date'] != '') {
+            $productData['special_from_date'] =  $this->dateFilter->filter($productData['special_from_date']);
             $productData['special_from_date'] = new \DateTime($productData['special_from_date']);
         }
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/18578
Fixed issue of 2.2.6 "Special price date from" Failed to parse time string

### Description (*)

In magento 2.2.6 when Account locale set to it_IT and admin user create one new product and set it's special price then it will gives error while saving the product that failed to parse time string. In this Pull Request I have fixed this issue. By modifing date format before it's parse to Date object.

### Fixed Issues (if relevant)

1. #18158: 2.2.6 "Special price date from" Failed to parse time string

### Steps to reproduce
1. Magento 2.2.6 create a new product with a price
2. Edit the new product and add a special price

### Expected result
1. The product has been saved

### Actual result
1. DateTime::__construct(): Failed to parse time string (20/09/2018) at position 0 (2): Unexpected character

### Manual testing scenarios (*)

1. Account locale set to it_IT if it's not set.
2. Add one new product and save. Than edit the product by adding special price and set from date as well. Press Save.
3. Product Save successfully that message will appear.
4. Now, Set another account locale and repeat the proceess, product will save successfully again.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
